### PR TITLE
style(US22): Revamp user account page and display user names

### DIFF
--- a/Frontend-user-interface/src/pages/MyAccount.js
+++ b/Frontend-user-interface/src/pages/MyAccount.js
@@ -2,34 +2,47 @@ import "../styles/MyAccount.css";
 import React, { useState, useEffect } from 'react'
 import { useNavigate} from "react-router-dom";
 
-import { Button } from '@mui/material';
 import LogoutIcon from '@mui/icons-material/Logout';
 import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
-import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Typography, Button, Box, Avatar,
+        Card, CardContent, List, ListItem, ListItemText, Divider } from '@mui/material';
 
 import { getAuth, onAuthStateChanged } from "firebase/auth";
-import { getFirestore, doc, deleteDoc } from "firebase/firestore";
+import { getFirestore, doc, deleteDoc, getDoc } from "firebase/firestore";
 
 const MyAccount = () => {
 
     const navigate = useNavigate();
     const auth = getAuth();
-
+    
     const [user, setUser] = useState(null);
-
+    const [userData, setUserData] = useState(null);
+    
     useEffect(() => {
         const unsubscribe = onAuthStateChanged(auth, (user) => {
             if (user) {
                 console.log("User is signed in");
                 setUser(user);
+                const db = getFirestore();
+                const docRef = doc(db, "users", user.uid);
+            
+                getDoc(docRef).then((docSnapshot) => {
+                if (docSnapshot.exists()) {
+                    setUserData(docSnapshot.data());
+                } else {
+                    console.log("No such document!");
+                }
+                }).catch((error) => {
+                console.log("Error getting document:", error);
+                });
             } else {
                 console.log("User is signed out");
             }
         });
 
-        // Cleanup subscription on unmount
         return () => unsubscribe();
-    }, []);
+    }, [user]);
 
     const [open, setOpen] = React.useState(false);
 
@@ -73,39 +86,60 @@ const MyAccount = () => {
     }
 
     return (
-        <div className="account-container">
-            <h1 className="account-title">Mon compte</h1>
-            <p className="account-text">Vous êtes connecté en tant que {user ? user.email : "No user"}</p>
-            <Button className="button-logout" onClick={logout} variant="contained" endIcon={<LogoutIcon />}>
-                Se déconnecter
-            </Button>
-            <Button className="Button" onClick={handleClickOpen} variant="contained" color="error" endIcon={<DeleteForeverIcon />}>
-                Supprimer mon compte
-            </Button>
-            <Dialog 
-                open={open}
-                onClose={handleClose}
-                aria-labelledby="alert-dialog-title"
-                aria-describedby="alert-dialog-description"
-            >
-                <DialogTitle id="alert-dialog-title">
-                    {"Confirmer la suppression de votre compte"}
-                </DialogTitle>
-                <DialogContent>
-                    <DialogContentText id="alert-dialog-description">
-                        Êtes-vous sûr de vouloir supprimer votre compte ? Cette action est irréversible!
-                    </DialogContentText>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={handleClose} color="primary">
-                        Annuler
-                    </Button>
-                    <Button onClick={deleteUser} color="error" autoFocus>
-                        Supprimer
-                    </Button>
-                </DialogActions>
-            </Dialog>
-        </div>
+        <Box className="account-container">
+            <Card elevation={10} style={{ backgroundColor: '#f5f5f5', border: '1px solid #f5f5f5', width: '20%', height: '50%' }}>
+                <CardContent>
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 2 }}>
+                        <Typography variant="h3" component="h1" className="account-title">Mon Compte</Typography>
+                        <Avatar sx={{ bgcolor: '#3F72AF' }}>
+                            <AccountCircleIcon />
+                        </Avatar>
+                    </Box>
+                    <List>
+                        <ListItem>
+                            <ListItemText primary="Nom" secondary={userData ? userData.lastname : ''} />
+                        </ListItem>
+                        <Divider component="li" />
+                        <ListItem>
+                            <ListItemText primary="Prénom" secondary={userData ? userData.firstname : ''} />
+                        </ListItem>
+                        <Divider component="li" />
+                        <ListItem>
+                            <ListItemText primary="Email" secondary={user?.email || ''} />
+                        </ListItem>
+                    </List>
+                    <Box className="button-logout">
+                        <Button variant="contained" startIcon={<LogoutIcon />} onClick={logout}>Se déconnecter</Button>
+                    </Box>
+                    <Box className="button-delete-account">
+                        <Button variant="contained" color="error" startIcon={<DeleteForeverIcon />} onClick={handleClickOpen}>Supprimer le compte</Button>
+                    </Box>
+                    <Dialog 
+                        open={open}
+                        onClose={handleClose}
+                        aria-labelledby="alert-dialog-title"
+                        aria-describedby="alert-dialog-description"
+                    >
+                        <DialogTitle id="alert-dialog-title">
+                            {"Confirmer la suppression de votre compte"}
+                        </DialogTitle>
+                        <DialogContent>
+                            <DialogContentText id="alert-dialog-description">
+                                Êtes-vous sûr de vouloir supprimer votre compte ? Cette action est irréversible!
+                            </DialogContentText>
+                        </DialogContent>
+                        <DialogActions>
+                            <Button onClick={handleClose} color="primary">
+                                Annuler
+                            </Button>
+                            <Button onClick={deleteUser} color="error" autoFocus>
+                                Supprimer
+                            </Button>
+                        </DialogActions>
+                    </Dialog>
+                </CardContent>
+            </Card>
+        </Box>
     )
 }
 


### PR DESCRIPTION
This commit brings a visual overhaul to the user account page for logged-in users. The changes include a refreshed design for an improved user experience. Additionally, the names and surnames of the connected users are now prominently displayed on the account page.

These enhancements aim to elevate the aesthetics and user-friendliness of the account page, providing users with a more personalized and visually appealing experience.

![image](https://github.com/AlassaneWone/RoomMapping/assets/115146900/cd527e67-7661-4f0c-a00f-3d1141c1dcc3)

US32-Page-compte-client