### PR TITLE
(US-17)[fixed-bug] gameList not updating

### DIFF
--- a/Frontend-user-interface/src/pages/GameList.js
+++ b/Frontend-user-interface/src/pages/GameList.js
@@ -16,6 +16,7 @@ const GameList = (props) => {
     const [creatingNewGame, setCreatingNewGame] = useState(false);
     const [selectedRow, setSelectedRow] = useState(null);
     const [gameDetails, setGameDetails] = useState(null);
+    const [gameAdded, setGameAdded] = useState(false);
 
     const handleCreateGame = () => {
         setCreatingNewGame(true);
@@ -49,12 +50,12 @@ const GameList = (props) => {
             if (user) {
                 const uid = user.uid;
                 fetchGames(uid);
-
             } else {
                 redirect('/login');
             }
         });
-    }, []);
+        setGameAdded(false);
+    }, [gameAdded]); 
 
     const buttonText = selectedRow ? "Détails" : "Aucun match Sélectionné";
 
@@ -63,7 +64,7 @@ const GameList = (props) => {
     if (!isLoaded) {
         return <div>Loading...</div>;
     } else if (creatingNewGame) {
-        return <NewGame onCancel={() => setCreatingNewGame(false)} mapId={props.mapId} url={props.url}/>;
+        return <NewGame onCancel={() => setCreatingNewGame(false)} mapId={props.mapId} url={props.url} onGameAdded={() => setGameAdded(true)}/>;
     } else if(gameDetails) {
         return <GameDetails onCancel={() => setGameDetails(false)} gameId={fetchData[selectedRow].gameId} mapId={props.mapId}/>;
     }

--- a/Frontend-user-interface/src/pages/NewGame.js
+++ b/Frontend-user-interface/src/pages/NewGame.js
@@ -149,6 +149,9 @@ const NewGame = (props) => {
             document.getElementsByClassName("errors")[0].style.display = "none";
             document.getElementsByClassName("success")[0].style.display = "block";
             resetForm();
+            if (props.onGameAdded) {
+                props.onGameAdded();
+            }
         };
 
         const errorDisplay = (errors) => {

--- a/Frontend-user-interface/src/styles/GameList.css
+++ b/Frontend-user-interface/src/styles/GameList.css
@@ -77,8 +77,7 @@ ul {
 
 .create-button {
     position: absolute;
-    bottom: 10px;
-    right: 10px;
+    bottom: 15px;   
     background-color: #91bdd3;
     color: black;
     padding: 10px;
@@ -86,12 +85,14 @@ ul {
     border-radius: 5px;
     cursor: pointer;
     font-size: 15px;
-font-weight: bold;
+    font-weight: bold;
 }
 
 .games-container {
     position: relative;
     margin: auto;
+    display: flex;
+    justify-content: center;
 }
 .empty-element {
     height: 54px; /* Adjust the height as needed to match your button's height */

--- a/Frontend-user-interface/tests/GameList.test.js
+++ b/Frontend-user-interface/tests/GameList.test.js
@@ -1,0 +1,80 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import GameList from "../src/pages/GameList";
+
+const fetchMock = jest.fn();
+global.fetch = fetchMock;
+
+const authMock = {
+  currentUser: {
+    uid: 'mocked-user-id',
+  },
+};
+
+// Mockez les fonctions Firebase nécessaires
+import { getAuth, onAuthStateChanged } from 'firebase/auth';
+
+jest.mock('firebase/auth', () => ({
+  __esModule: true,
+  ...jest.requireActual('firebase/auth'),
+  getAuth: jest.fn(() => authMock),
+  onAuthStateChanged: jest.fn(),
+}));
+
+describe("GameList Component", () => {    
+  test("Renders GameList after Firebase authentication", async () => {
+    const mockUser = { uid: 'mock-user-id' };
+
+    // Utilisez directement les fonctions mockées
+    getAuth.mockReturnValueOnce(authMock);
+    onAuthStateChanged.mockImplementationOnce((auth, callback) => callback(authMock.currentUser));
+
+    // Mockez la réponse de l'appel API
+    const mockApiResponse = 
+      [
+        {
+          gameId: "random-game-id-1",
+          date: "2024-12-27T17:28:00.000Z",
+          name: "test 1",
+          teams: [
+            { name: "abc", roomId: "test-room-1-team-1" },
+            { name: "def", roomId: "test-room-1-team-2" },
+          ],
+        },
+      ];
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValueOnce(mockApiResponse),
+    });
+
+    const { rerender } = render(<GameList mapId="test-map-id" url="test-url" />);
+
+    // Attendez que l'authentification se produise
+    await waitFor(() => {
+      expect(screen.getByText("test 1")).toBeInTheDocument();
+      console.log(screen.debug());
+    });
+
+    mockApiResponse.push(
+        {
+          gameId: "random-game-id-2",
+          date: "2023-12-27T11:34:00.000Z",
+          name: "test 2",
+          teams: [
+            { name: "alpha", roomId: "test-room-2-team-1" },
+            { name: "beta", roomId: "test-room-2-team-2" },
+            { name: "charlie", roomId: "test-room-2-team-3" },
+          ],
+        },
+    );
+
+      rerender(<GameList mapId="test-map-id" url="test-url" />);
+
+      await waitFor(() => {
+        expect(screen.getByText("test 2")).toBeInTheDocument();
+        console.log(screen.debug());
+      });
+  });
+});


### PR DESCRIPTION
Reproduce bug:

opening the list of matches (whether by clicking on the map settings then "matchs" OR by pressing "RETOUR" when creating a new match) can only be updated by refreshing the pop up.

What i did:

Added a useState constant  which allows, when called in the useEffect, to refresh the list.

Note:

Additionally, a small css error caused the “Créer un nouveau match” button to end up to the right of its parent. Fixed.